### PR TITLE
feat(ci): create setup-nexus-go action

### DIFF
--- a/oe-cli/action.yml
+++ b/oe-cli/action.yml
@@ -1,9 +1,0 @@
-name: setup-oe-cli
-inputs:
-  foo:
-    required: true
-runs:
-  using: "composite"
-  steps:
-    - run: echo ${{ inputs.foo }}
-      shell: bash

--- a/setup-nexus-go/action.yml
+++ b/setup-nexus-go/action.yml
@@ -14,7 +14,9 @@ runs:
         echo GOPROXY=https://${{ inputs.endpoint }}/repository/go >> $GITHUB_ENV
         echo GOSUMDB="sum.golang.org https://${{ inputs.endpoint }}/repository/gosumdb" >> $GITHUB_ENV
         rm -f ~/.netrc
-        echo machine ${{ inputs.endpoint }} >> ~/.netrc
-        echo login ${{ inputs.login }} >> ~/.netrc
-        echo password ${{  inputs.password }} >> ~/.netrc
+        cat << EOF > ~/.netrc
+        machine ${{ inputs.endpoint }}
+        login ${{ inputs.login }}
+        password ${{  inputs.password }}
+        EOF
       shell: bash

--- a/setup-nexus-go/action.yml
+++ b/setup-nexus-go/action.yml
@@ -1,4 +1,4 @@
-name: setup-oe
+name: setup-nexus-go
 inputs:
   endpoint:
     required: true
@@ -11,9 +11,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-go@v3
-      with:
-        go-version: '^1.18.3'
     - run: |
         export GONOSUMDB=github.com/sportsball-ai
         export GOPROXY=https://${{ inputs.endpoint }}/repository/go
@@ -22,5 +19,4 @@ runs:
         echo machine ${{ inputs.endpoint }} >> ~/.netrc
         echo login ${{ inputs.login }} >> ~/.netrc
         echo password ${{  inputs.password }} >> ~/.netrc
-        go install github.com/sportsball-ai/oe-cli/cmds/oe@${{ inputs.version }}
       shell: bash

--- a/setup-nexus-go/action.yml
+++ b/setup-nexus-go/action.yml
@@ -10,9 +10,9 @@ runs:
   using: composite
   steps:
     - run: |
-        export GONOSUMDB=github.com/sportsball-ai
-        export GOPROXY=https://${{ inputs.endpoint }}/repository/go
-        export GOSUMDB="sum.golang.org https://${{ inputs.endpoint }}/repository/gosumdb"
+        echo GONOSUMDB=github.com/sportsball-ai >> $GITHUB_ENV
+        echo GOPROXY=https://${{ inputs.endpoint }}/repository/go >> $GITHUB_ENV
+        echo GOSUMDB="sum.golang.org https://${{ inputs.endpoint }}/repository/gosumdb" >> $GITHUB_ENV
         rm -f ~/.netrc
         echo machine ${{ inputs.endpoint }} >> ~/.netrc
         echo login ${{ inputs.login }} >> ~/.netrc

--- a/setup-nexus-go/action.yml
+++ b/setup-nexus-go/action.yml
@@ -13,7 +13,6 @@ runs:
         echo GONOSUMDB=github.com/sportsball-ai >> $GITHUB_ENV
         echo GOPROXY=https://${{ inputs.endpoint }}/repository/go >> $GITHUB_ENV
         echo GOSUMDB="sum.golang.org https://${{ inputs.endpoint }}/repository/gosumdb" >> $GITHUB_ENV
-        rm -f ~/.netrc
         cat << EOF > ~/.netrc
         machine ${{ inputs.endpoint }}
         login ${{ inputs.login }}

--- a/setup-nexus-go/action.yml
+++ b/setup-nexus-go/action.yml
@@ -2,8 +2,6 @@ name: setup-nexus-go
 inputs:
   endpoint:
     required: true
-  version:
-    required: true
   login:
     required: true
   password:

--- a/setup-oe/action.yml
+++ b/setup-oe/action.yml
@@ -12,6 +12,8 @@ runs:
   using: composite
   steps:
     - uses: actions/setup-go@v3
+      with:
+        go-version: '^1.18.3'
     - run: |
         export GONOSUMDB=github.com/sportsball-ai
         export GOPROXY=https://${{ inputs.endpoint }}/repository/go

--- a/setup-oe/action.yml
+++ b/setup-oe/action.yml
@@ -4,11 +4,19 @@ inputs:
     required: true
   version:
     required: true
+  login:
+    required: true
+  password:
+    required: true
 runs:
   using: composite
   steps:
     - run: |
         export GONOSUMDB=github.com/sportsball-ai
-        export GOPROXY=${{ inputs.endpoint }}/repository/go
-        export GOSUMDB="sum.golang.org ${{ inputs.endpoint }}/repository/gosumdb"
+        export GOPROXY=https://${{ inputs.endpoint }}/repository/go
+        export GOSUMDB="sum.golang.org https://${{ inputs.endpoint }}/repository/gosumdb"
+        rm -f ~/.netrc
+        echo machine ${{ inputs.endpoint }} >> ~/.netrc
+        echo login ${{ inputs.login }} >> ~/.netrc
+        echo password ${{  inputs.password }} >> ~/.netrc
         go install github.com/sportsball-ai/oe-cli/cmds/oe@${{ inputs.version }}

--- a/setup-oe/action.yml
+++ b/setup-oe/action.yml
@@ -20,4 +20,4 @@ runs:
         echo login ${{ inputs.login }} >> ~/.netrc
         echo password ${{  inputs.password }} >> ~/.netrc
         go install github.com/sportsball-ai/oe-cli/cmds/oe@${{ inputs.version }}
-    - shell: bash
+      shell: bash

--- a/setup-oe/action.yml
+++ b/setup-oe/action.yml
@@ -20,3 +20,4 @@ runs:
         echo login ${{ inputs.login }} >> ~/.netrc
         echo password ${{  inputs.password }} >> ~/.netrc
         go install github.com/sportsball-ai/oe-cli/cmds/oe@${{ inputs.version }}
+    - shell: bash

--- a/setup-oe/action.yml
+++ b/setup-oe/action.yml
@@ -1,0 +1,14 @@
+name: setup-oe
+inputs:
+  endpoint:
+    required: true
+  version:
+    required: true
+runs:
+  using: composite
+  steps:
+    - run: |
+        export GONOSUMDB=github.com/sportsball-ai
+        export GOPROXY=${{ inputs.endpoint }}/repository/go
+        export GOSUMDB="sum.golang.org ${{ inputs.endpoint }}/repository/gosumdb"
+        go install github.com/sportsball-ai/oe-cli/cmds/oe@${{ inputs.version }}

--- a/setup-oe/action.yml
+++ b/setup-oe/action.yml
@@ -11,6 +11,7 @@ inputs:
 runs:
   using: composite
   steps:
+    - uses: actions/setup-go@v3
     - run: |
         export GONOSUMDB=github.com/sportsball-ai
         export GOPROXY=https://${{ inputs.endpoint }}/repository/go

--- a/version/action.yml
+++ b/version/action.yml
@@ -1,9 +1,0 @@
-name: version
-inputs:
-  foo:
-    required: true
-runs:
-  using: composite
-  steps:
-    - run: echo ${{ inputs.foo }}
-      shell: bash


### PR DESCRIPTION
This PR will allow developers to use the setup-nexus-go composite action within their workflows. See the following example.

  - uses: actions/setup-go@v3
    with:
      go-version: '^1.13.1'
  - name: Set up setup-nexus-go
    uses: sportsball-ai/actions-hub/setup-nexus-go@setup-oe
    with:
      endpoint:
      login: ${{ secrets.some_login }}
      password: ${{ secrets.some_password }}
  - name: install proprietary package
    run: |
      go mod init github.com/jonathankao97/test
      go get github.com/proprietary@version