### PR TITLE
feat: setup-nexus-npm

### DIFF
--- a/setup-nexus-npm/action.yml
+++ b/setup-nexus-npm/action.yml
@@ -11,7 +11,9 @@ runs:
   steps:
     - run: |
         rm -f ~/.npmrc
-        echo registry=https://${{ inputs.endpoint }}/repository/npm-txm >> ~/.npmrc
-        echo _auth=$(echo -n ${{ inputs.login }}:${{ inputs.password }} | base64) >> ~/.npmrc
+        cat << EOF > ~/.npmrc
+        registry=https://${{ inputs.endpoint }}/repository/npm-txm
+        _auth=$(echo -n ${{ inputs.login }}:${{ inputs.password }} | base64)
+        EOF
         source ~/.npmrc
       shell: bash

--- a/setup-nexus-npm/action.yml
+++ b/setup-nexus-npm/action.yml
@@ -10,10 +10,8 @@ runs:
   using: composite
   steps:
     - run: |
-        rm -f ~/.npmrc
         cat << EOF > ~/.npmrc
         registry=https://${{ inputs.endpoint }}/repository/npm-txm
         _auth=$(echo -n ${{ inputs.login }}:${{ inputs.password }} | base64)
         EOF
-        source ~/.npmrc
       shell: bash

--- a/setup-nexus-npm/action.yml
+++ b/setup-nexus-npm/action.yml
@@ -1,0 +1,17 @@
+name: setup-nexus-npm
+inputs:
+  endpoint:
+    required: true
+  login:
+    required: true
+  password:
+    required: true
+runs:
+  using: composite
+  steps:
+    - run: |
+        rm -f ~/.npmrc
+        echo registry=https://${{ inputs.endpoint }}/repository/npm-txm >> ~/.npmrc
+        echo _auth=$(echo -n ${{ inputs.login }}:${{ inputs.password }} | base64) >> ~/.npmrc
+        source ~/.npmrc
+      shell: bash


### PR DESCRIPTION
This PR will allow developers to use the setup-nexus-npm composite action within their workflows. See the following example.

- uses: actions/setup-node@v3
  with:
    node-version: 14
- name: Set up setup-nexus-npm
  uses: sportsball-ai/actions-hub/setup-nexus-npm@setup-nexus-npm
  with:
    endpoint: <some top secret endpoint>
    login: ${{ secrets.some_login }}
    password: ${{ secrets.some_password }} 
- name: install with npm
  run: |
    npm install <some proprietary package>