### PR TITLE
feat: setup-nexus-python

### DIFF
--- a/setup-nexus-python/action.yml
+++ b/setup-nexus-python/action.yml
@@ -10,14 +10,12 @@ runs:
   using: composite
   steps:
     - run: |
-        rm -f ~/.config/pip/pip.conf
         mkdir -p ~/.config/pip
         cat << EOF > ~/.config/pip/pip.conf
         [global]
         index = https://${{ inputs.endpoint }}/repository/python/pypi
         index-url = https://${{ inputs.endpoint }}/repository/python/simple
         EOF
-        rm -f ~/.netrc
         cat << EOF > ~/.netrc
         machine ${{ inputs.endpoint }}
         login ${{ inputs.login }}

--- a/setup-nexus-python/action.yml
+++ b/setup-nexus-python/action.yml
@@ -12,11 +12,15 @@ runs:
     - run: |
         rm -f ~/.config/pip/pip.conf
         mkdir -p ~/.config/pip
-        echo "[global]" >> ~/.config/pip/pip.conf
-        echo "index = https://${{ inputs.endpoint }}/repository/python/pypi" >> ~/.config/pip/pip.conf
-        echo "index-url = https://${{ inputs.endpoint }}/repository/python/simple" >> ~/.config/pip/pip.conf
+        cat << EOF > ~/.config/pip/pip.conf
+        [global]
+        index = https://${{ inputs.endpoint }}/repository/python/pypi
+        index-url = https://${{ inputs.endpoint }}/repository/python/simple
+        EOF
         rm -f ~/.netrc
-        echo machine ${{ inputs.endpoint }} >> ~/.netrc
-        echo login ${{ inputs.login }} >> ~/.netrc
-        echo password ${{  inputs.password }} >> ~/.netrc
+        cat << EOF > ~/.netrc
+        machine ${{ inputs.endpoint }}
+        login ${{ inputs.login }}
+        password ${{  inputs.password }}
+        EOF
       shell: bash

--- a/setup-nexus-python/action.yml
+++ b/setup-nexus-python/action.yml
@@ -1,0 +1,19 @@
+name: setup-nexus-python
+inputs:
+  endpoint:
+    required: true
+  login:
+    required: true
+  password:
+    required: true
+runs:
+  using: composite
+  steps:
+    - run: |
+        rm -f ~/.config/pip/pip.conf
+        echo "[global]\nindex = https://${{ inputs.endpoint }}/repository/python/pypi\nindex-url = https://${{ inputs.endpoint }}/repository/python/simple" >> ~/.config/pip/pip.conf
+        rm -f ~/.netrc
+        echo machine ${{ inputs.endpoint }} >> ~/.netrc
+        echo login ${{ inputs.login }} >> ~/.netrc
+        echo password ${{  inputs.password }} >> ~/.netrc
+      shell: bash

--- a/setup-nexus-python/action.yml
+++ b/setup-nexus-python/action.yml
@@ -11,6 +11,7 @@ runs:
   steps:
     - run: |
         rm -f ~/.config/pip/pip.conf
+        mkdir -p ~/.config/pip
         echo "[global]\nindex = https://${{ inputs.endpoint }}/repository/python/pypi\nindex-url = https://${{ inputs.endpoint }}/repository/python/simple" >> ~/.config/pip/pip.conf
         rm -f ~/.netrc
         echo machine ${{ inputs.endpoint }} >> ~/.netrc

--- a/setup-nexus-python/action.yml
+++ b/setup-nexus-python/action.yml
@@ -12,7 +12,9 @@ runs:
     - run: |
         rm -f ~/.config/pip/pip.conf
         mkdir -p ~/.config/pip
-        echo "[global]\nindex = https://${{ inputs.endpoint }}/repository/python/pypi\nindex-url = https://${{ inputs.endpoint }}/repository/python/simple" >> ~/.config/pip/pip.conf
+        echo "[global]" >> ~/.config/pip/pip.conf
+        echo "index = https://${{ inputs.endpoint }}/repository/python/pypi" >> ~/.config/pip/pip.conf
+        echo "index-url = https://${{ inputs.endpoint }}/repository/python/simple" >> ~/.config/pip/pip.conf
         rm -f ~/.netrc
         echo machine ${{ inputs.endpoint }} >> ~/.netrc
         echo login ${{ inputs.login }} >> ~/.netrc


### PR DESCRIPTION
This PR will allow developers to use the setup-nexus-python composite action within their workflows. See the following example.
- uses: actions/setup-python@v4
  with:
    python-version: '3.x'
- name: Set up setup-nexus-python
  uses: sportsball-ai/actions-hub/setup-nexus-python@setup-nexus-python
  with:
    endpoint: <insert endpoint here to avoid leaking endpoint to public>
    login: ${{ secrets.some_login }}
    password: ${{ secrets.some_password }}
- name: install proprietary python packages
  run: |
    pip3 install <insert_package_here>
    pip3 install django
- name: do some other stuff