### PR TITLE
OE-357 remove deprecated output format

### DIFF
--- a/.github/workflows/calculate-version.yml
+++ b/.github/workflows/calculate-version.yml
@@ -45,4 +45,4 @@ jobs:
           echo "branch name: $GITHUB_HEAD_REF"
           NEW_VERSION_TAG=$(oe version -i -b $GITHUB_HEAD_REF) && export NEW_VERSION_TAG
           echo "new version: $NEW_VERSION_TAG"
-          echo "::set-output name=version::$NEW_VERSION_TAG"
+          echo "{version}={NEW_VERSION_TAG}" >> $GITHUB_OUTPUT

--- a/major-version-tag/action.yml
+++ b/major-version-tag/action.yml
@@ -15,5 +15,5 @@ runs:
         version=${{ inputs.version }}
         MAJOR_VERSION=(${version//./ })
         echo "major version is $MAJOR_VERSION"
-        echo "::set-output name=major_version::$MAJOR_VERSION"
+        echo "{major_version}={MAJOR_VERSION}" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
this fixes 

Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/