### PR TITLE
OE-373 create v2 of actions hub workflows to use txm-cli instead of o…

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,11 +1,11 @@
 # calculate-version
 
-A github action reusable workflow that uses `oe-cli` to calculate the next version of code
+A github action reusable workflow that uses `txm-cli` to calculate the next version of code
 
 ## Example Usage with Npm
 
 ```yaml
-name: oe-version
+name: txm-version
 
 on:
   pull_request:
@@ -19,7 +19,7 @@ jobs:
     if: github.event.pull_request.merged == true
     uses: sportsball-ai/actions-hub/.github/workflows/calculate-version.yml@<VERSION>
     with:
-      version: <OE-CLI_VERSION>
+      version: <TXM-CLI_VERSION>
     secrets: inherit
 
   npm_version_tag:
@@ -52,7 +52,7 @@ jobs:
 ## Example Usage without Npm
 
 ```yaml
-name: oe-version
+name: txm-version
 
 on:
   pull_request:
@@ -66,7 +66,7 @@ jobs:
     if: github.event.pull_request.merged == true
     uses: sportsball-ai/actions-hub/.github/workflows/calculate-version.yml@<VERSION>
     with:
-      version: <OE-CLI_VERSION>
+      version: <TXM-CLI_VERSION>
     secrets: inherit
 
   git_version_tag:

--- a/.github/workflows/calculate-version.yml
+++ b/.github/workflows/calculate-version.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       version:
-        description: the version of oe-cli to use
+        description: the version of txm-cli to use
         required: true
         type: string
 
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/sportsball-ai/oe-cli:${{ inputs.version }}
+      image: ghcr.io/sportsball-ai/txm-cli:${{ inputs.version }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -41,9 +41,9 @@ jobs:
       - name: calculate latest version
         id: calculate-version
         run: |
-          echo "current version: $(oe version)"
+          echo "current version: $(txm version)"
           echo "branch name: $GITHUB_HEAD_REF"
-          NEW_VERSION_TAG=$(oe version -i -b $GITHUB_HEAD_REF) && export NEW_VERSION_TAG
+          NEW_VERSION_TAG=$(txm version -i -b $GITHUB_HEAD_REF) && export NEW_VERSION_TAG
           echo "new version: $NEW_VERSION_TAG"
           echo "version=$NEW_VERSION_TAG" >> $GITHUB_OUTPUT
           if [[ -z "${GITHUB_OUTPUT}" ]]; then echo "GITHUB_OUTPUT zero length or unset! Aborting"; exit 1; fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # actions-hub
 
-Actions hub will serve as a store for sportsball-ai's shared composite actions. This allows developers to create commonly used generic github actions to be used throughout the organization. This also makes it easy for developers to adopt custom tooling built within the organization within their CI pipelines. 
+Actions hub will serve as a store for sportsball-ai's shared workflows and composite actions. This allows developers to create commonly used generic github actions to be used throughout the organization. This also makes it easy for developers to adopt custom tooling built within the organization within their CI pipelines. 
 
 It is important to note that this repository is `public`, due to limitations on Github's sharing of actions resources between private repositories. In the future, if sportsball-ai is upgraded to an enterprise account, it may be possible to mark this repository as `internal` and follow an innersource approach. 
 
@@ -26,47 +26,18 @@ runs:
 
 ## Usage
 
-Each composite action will contain a README `<name>/README.md` with documentation and examples about how to use that particular action.
-
-### Example
-
-```yml
-name: oe-cli
-
-on:
-  push:
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Set up oe-cli
-        uses: sportsball-ai/actions-hub/oe-cli@main
-        with:
-          foo: oe-cli-says-hello-world!
-      - name: Version using oe-cli
-        uses: sportsball-ai/actions-hub/version@main
-        with:
-          foo: oe-cli-version!
-      - name: Do some linting
-        run: |
-          echo lint
-      - name: Do some testing
-        run: |
-          echo test
-```
+Each composite action added must contain a README `<name>/README.md` with documentation and examples about how to use that particular action.  See existing actions for examples of their associated README.
 
 ## Versioning
 
 Whenever a shared workflow or composite action from this repo is called from within your workflow, it must have a tag reference so it can be properly identified, e.g. `uses: sportsball-ai/actions-hub/git-version-tag@main`
 
-While it is possible to just use `@main` to get the latest head of the repo on the main branch, main/HEAD is currently tagged as "v1".  This is so that we can identify when a breaking change is introduced and thus introduce new functionality without breaking existing external references to this repo.
+While it is possible to just use `@main` to get the latest head of the repo on the main branch, main/HEAD is currently tagged as "v2".  This is so that we can identify when a breaking change is introduced and thus introduce new functionality without breaking existing external references to this repo (i.e. v1).
 
 **Note**
 If you are contributing to this repo, please consider whether you are introducing a breaking change or not, i.e is this a feature, patch or deprecation. 
 
 Once your PR is approved and merged:
-- for a non-breaking change, please move the v1 tag (or whatever tag represents the most current version) to the current main/HEAD.
+- for a non-breaking change, please move the v2 tag (or whatever tag represents the most current version) to the new commit on main/HEAD by removing the previous vN tag and recreating it on the current commit at main/HEAD.  Then push the tag to github.
 
-- if you are introducing a deprecation, i.e. a removal of previous functionality, then please create the next logical vN tag on the current main/HEAD
+- if you are introducing a deprecation, i.e. a removal of previous functionality, then please create the next logical vN tag on the current main/HEAD and push that new tag to github.

--- a/git-version-tag/README.md
+++ b/git-version-tag/README.md
@@ -5,7 +5,7 @@ A composite action that takes in a version number and tags the next version of c
 ## Example Usage
 
 ```yaml
-name: oe-version
+name: git-version-tag-example
 
 on:
   pull_request:
@@ -19,7 +19,7 @@ jobs:
     if: github.event.pull_request.merged == true
     uses: sportsball-ai/actions-hub/.github/workflows/calculate-version.yml@<VERSION>
     with:
-      version: <OE-CLI_VERSION>
+      version: <TXM-CLI_VERSION>
     secrets: inherit
 
   git_version_tag:

--- a/major-version-tag/README.md
+++ b/major-version-tag/README.md
@@ -2,7 +2,7 @@
 
 A composite action that takes a txm standard version number (vM.m.p) and returns the major version/revision (vM)
 
-In the following example, in the "calculate-version" job, we specify the major version of oe-cli to use for versioning (v0).
+In the following example, in the "calculate-version" job, we specify the major version of txm-cli to use for versioning (v2).
 
 In the "build_and_tag_new_image" job, we use the "major-version-tag" composite action to get the major version of the new, current version.
 
@@ -23,11 +23,11 @@ on:
 jobs:
   calculate-version:
     if: github.event.pull_request.merged == true
-    uses: sportsball-ai/actions-hub/.github/workflows/calculate-version.yml@v1
+    uses: sportsball-ai/actions-hub/.github/workflows/calculate-version.yml@v2
     with:
       # in the case of this calculate-version shared workflow, this is the major version of oe-cli to use for versioning
       # the major version tag can be used to get the latest major revision of any artifact that is versioned using this approach
-      version: v0
+      version: v2
     secrets: inherit
 
   git_version_tag:
@@ -43,7 +43,7 @@ jobs:
             echo ${{ needs.calculate-version.outputs.version }}
 
         - name: git tag
-          uses: sportsball-ai/actions-hub/git-version-tag@v1
+          uses: sportsball-ai/actions-hub/git-version-tag@v2
           with:
             version: ${{ needs.calculate-version.outputs.version }}
 
@@ -61,7 +61,7 @@ jobs:
         # this composite action will produce the major version tag for a given version
       - name: get major version tag
         id: major_version_tag
-        uses: sportsball-ai/actions-hub/major-version-tag@v1
+        uses: sportsball-ai/actions-hub/major-version-tag@v2
         with: 
           version: ${{ needs.calculate-version.outputs.version }}
 
@@ -85,7 +85,7 @@ jobs:
 ```
 
 The above ensures that with each run of the workflow:
-- the latest oe-cli docker image for the specified major version is used to handle versioning of the artifact being built in the workflow
+- the latest txm-cli docker image for the specified major version is used to handle versioning of the artifact being built in the workflow
 - a new, TXM standard version is generated (vM.m.p) for the artifact being built/versioned in the workflow (in this case a docker image)
 - any feature (i.e. a minor version bump) will produce the same major version tag via the "major-version-tag" composite action
 - because docker tags must be unique, this same major version tag will follow/move to the latest major version of the artifact with each push to GHCR.

--- a/npm-version-tag/README.md
+++ b/npm-version-tag/README.md
@@ -5,7 +5,7 @@ A composite action that takes in a version number and tags the next version of c
 ## Example Usage
 
 ```yaml
-name: oe-version
+name: npm-version-tag-example
 
 on:
   pull_request:
@@ -19,7 +19,7 @@ jobs:
     if: github.event.pull_request.merged == true
     uses: sportsball-ai/actions-hub/.github/workflows/calculate-version.yml@<VERSION>
     with:
-      version: <OE-CLI_VERSION>
+      version: <TXM-CLI_VERSION>
     secrets: inherit
 
   npm_version_tag:


### PR DESCRIPTION
…e-cli

- this updates the calculate-version.yaml workflow to use txm-cli instead of oe-cli.  
- It also updates various readme's to 
   - reference the proper versions of what will become v2 of the shared workflows and composite actions in this repo after this PR is merged.
   - reference txm-cli rather than oe-cli where appropriate