### PR TITLE
Feature/FTR-174

### DIFF
--- a/setup-nexus-npm/README.md
+++ b/setup-nexus-npm/README.md
@@ -1,17 +1,17 @@
 # setup-nexus-npm
 
-A composite github action for creating a .npmrc file that will point to the npm repositories in nexus
+A composite github action for creating a .npmrc file that will point to the npm repositories in nexus.  This allows developers to use Nexus to both access TXM internal Node modules as well as as a proxy for all Node dependencies.
 
 ## Parameters
-- username: the username for accessing the npm repositories in nexus, typically provided as a secret from the calling workflow
-- password: the password for accessing the npm repositories in nexus, typically provided as a secret from the calling workflow
+- username: Required. The username for accessing the npm repositories in nexus, typically provided as a secret from the calling workflow
+- password: Required. The password for accessing the npm repositories in nexus, typically provided as a secret from the calling workflow
 
 ## Example Usage
 
 ```yaml
 - uses: actions/setup-node@v3
   with:
-    node-version: 16
+    node-version: 18
 - name: setup-nexus-npm
   uses: sportsball-ai/actions-hub/setup-nexus-npm@<VERSION>
   with:

--- a/setup-nexus-npm/README.md
+++ b/setup-nexus-npm/README.md
@@ -15,6 +15,6 @@ A composite github action for creating a .npmrc file that will point to the npm 
 - name: setup-nexus-npm
   uses: sportsball-ai/actions-hub/setup-nexus-npm@<VERSION>
   with:
-    login: ${{ secrets.USERNAME }}
+    username: ${{ secrets.USERNAME }}
     password: ${{ secrets.PASSWORD }}    
 ```

--- a/setup-nexus-npm/README.md
+++ b/setup-nexus-npm/README.md
@@ -1,22 +1,20 @@
 # setup-nexus-npm
 
-Configure a github action to point towards a self hosted Npm repository. After usage, any calls to `npm install` will point towards the repository at the endpoint provided.
+A composite github action for creating a .npmrc file that will point to the npm repositories in nexus
 
 ## Parameters
-- Endpoint: the npm registry endpoint
-- Login: the login for the self hosted npm repository, typically stored as a secret
-- Password: the password for the self hosted npm repository, typically stored as a secret
+- username: the username for accessing the npm repositories in nexus, typically provided as a secret from the calling workflow
+- password: the password for accessing the npm repositories in nexus, typically provided as a secret from the calling workflow
 
 ## Example Usage
 
 ```yaml
 - uses: actions/setup-node@v3
   with:
-    node-version: 14
-- name: Set up setup-nexus-npm
+    node-version: 16
+- name: setup-nexus-npm
   uses: sportsball-ai/actions-hub/setup-nexus-npm@<VERSION>
   with:
-    endpoint: <URL>
-    login: ${{ secrets.LOGIN }}
+    login: ${{ secrets.USERNAME }}
     password: ${{ secrets.PASSWORD }}    
 ```

--- a/setup-nexus-npm/action.yml
+++ b/setup-nexus-npm/action.yml
@@ -14,3 +14,4 @@ runs:
         _auth=$(echo -n ${{ inputs.username }}:${{ inputs.password }} | base64)
         EOF
       shell: bash
+      

--- a/setup-nexus-npm/action.yml
+++ b/setup-nexus-npm/action.yml
@@ -1,8 +1,6 @@
 name: setup-nexus-npm
 inputs:
-  endpoint:
-    required: true
-  login:
+  username:
     required: true
   password:
     required: true
@@ -11,7 +9,8 @@ runs:
   steps:
     - run: |
         cat << EOF > ~/.npmrc
-        registry=https://${{ inputs.endpoint }}/repository/npm-txm
-        _auth=$(echo -n ${{ inputs.login }}:${{ inputs.password }} | base64)
+        registry=https://nexus.txm.tools/repository/npm/
+        @txm:registry=https://nexus.txm.tools/repository/npm-txm/
+        _auth=$(echo -n ${{ inputs.username }}:${{ inputs.password }} | base64)
         EOF
       shell: bash


### PR DESCRIPTION
Getting back to fixing this, there were some learnings and some problems with the original.
-  README was confusing and needed updating
- - called out that this is a composite action (as opposed to a shared workflow)
- - changed the 'login' parameter to 'username' - because it's a username, not a login
- - updated example usage accordingly
- adds npm-txm to the .npmrc

Learnings are that composite actions don't allow the direct use of secrets, so setting default secrets for username and password here won't work, the secrets must be passed as parameters from the calling workflow.  As per the last attempt at fixing this, my understanding is that we have agreed to keep this functionality simple and true to its name, which is to setup our nexus npm repos and nothing more.  This is why there is no longer an endpoint parameter and why we make no assumptions about default username and password - they must be provided by the caller.

If we want a more flexible and configurable setup for npm, this should probably be done as a shared workflow.

This change has been validated using actions-hub-test and actions-test repos.  Upon merge, this change will be tagged v3 as these changes differ from v2.